### PR TITLE
chore: github actions code quality

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,37 @@
+name: Code Quality
+
+on:
+  push:
+    branches: ["main"]
+    paths-ignore:
+      - ".github/ISSUE_TEMPLATE/**"
+      - "doc"
+      - "CODEOWNERS"
+      - "CONTIBUTING.md"
+      - "LICENSE"
+      - "README.md"
+  pull_request:
+    branches: ["main"]
+    paths-ignore:
+      - ".github/ISSUE_TEMPLATE/**"
+      - "doc"
+      - "CODEOWNERS"
+      - "CONTIBUTING.md"
+      - "LICENSE"
+      - "README.md"
+
+jobs:
+  nodejs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: "npm"
+      - name: Install Dependencies
+        run: npm ci
+    #   - name: Perform linting on the code
+    #     run: npm run lint


### PR DESCRIPTION
Will uncomment the `npm run lint` before final approval. This is commented out as the ESLint/Prettier PR is not merged yet.