### PR TITLE
Adding hovertips aka tooltips to chat and transcribe header links.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
 				"uuid": "^9.0.1"
 			},
 			"devDependencies": {
+				"@svelte-plugins/tooltips": "^3.0.0",
 				"@sveltejs/adapter-auto": "^2.0.0",
 				"@sveltejs/adapter-node": "^1.3.1",
 				"@sveltejs/kit": "^1.20.4",
@@ -666,6 +667,15 @@
 				"rollup": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@svelte-plugins/tooltips": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@svelte-plugins/tooltips/-/tooltips-3.0.0.tgz",
+			"integrity": "sha512-lE7LKU01OY8XYwsWmRxEcBZJqVv+f/TP5JQP5eqzb9ppS9UeN8DF/mFP9i2BfELRfYdwl4qwUENTPYBndMI3LA==",
+			"dev": true,
+			"peerDependencies": {
+				"svelte": "^3.54.0 || ^4.0.0 || ^5.0.0-next.0"
 			}
 		},
 		"node_modules/@sveltejs/adapter-auto": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {
+		"@svelte-plugins/tooltips": "^3.0.0",
 		"@sveltejs/adapter-auto": "^2.0.0",
 		"@sveltejs/adapter-node": "^1.3.1",
 		"@sveltejs/kit": "^1.20.4",

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,9 +4,16 @@
 	import ApiIndicator from "$lib/components/apiIndicator.svelte";
 	import settings from "$lib/settings";
 	import { env } from "$env/dynamic/public";
+	import { tooltip } from "@svelte-plugins/tooltips";
 
 	const branding: Boolean = env.PUBLIC_AI4NS_BRANDING === "true" ? true : false;
 </script>
+
+<style>
+	:global(.tooltip.homepage-tooltip) {
+    	--tooltip-color: #fff;
+	}
+</style>
 
 <!-- Title Bar -->
 <div
@@ -28,11 +35,27 @@
 		{/if}
 	</div>
 	<div class="flex items-center">
-		<a href="/chat">Chat</a>
+		<a href="/chat" use:tooltip={{
+			content: "Interact with the Chat, set your persona, and label your conversations. Ask me.... <some sample question>",
+			position: "bottom",
+			autoPosition: true,
+			align: "center",
+			animation: "slide",
+			action: "hover",
+			theme: "homepage-tooltip"
+		}}>Chat</a>
 		<ApiIndicator type={$settings.chatModel} />
 	</div>
 	<div class="flex items-center">
-		<a href="/upload">Transcribe</a>
+		<a href="/upload" use:tooltip={{
+			content: "Upload a video or audio file and get a summarization or translation!",
+			position: "bottom",
+			autoPosition: true,
+			align: "center",
+			animation: "slide",
+			action: "hover",
+			theme: "homepage-tooltip"
+		}}>Transcribe</a>
 		<ApiIndicator type={$settings.transcriptionModel} />
 	</div>
 	<div>


### PR DESCRIPTION
Good day!

Was checking out issues on leapfrogai-ui and saw one i'd like to propose here. It's from #117  asking about adding some informational hover tips to those links. I saw a plugin from Svelte around tooltips and thought it could be used for such functionality.

Thanks for taking the time to review. I didn't see any 'tests' to modify or add for this, but I did run the check script locally.

Thanks!

![image](https://github.com/defenseunicorns/leapfrogai-ui/assets/1834551/3164d22b-2a38-4376-b493-9950e556b630)

![image](https://github.com/defenseunicorns/leapfrogai-ui/assets/1834551/83ebc134-5bb2-46da-91df-e3e86fd78fa5)
